### PR TITLE
fix: check workspace repo based on the existence of folder contracts

### DIFF
--- a/src/dtos/requests/update-verification-status.request.ts
+++ b/src/dtos/requests/update-verification-status.request.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsNotEmpty } from 'class-validator';
-import { CONTRACT_VERIFICATION } from 'src/common';
+import { CONTRACT_VERIFICATION } from '../../common';
 
 export class UpdateVerificationStatusRequest {
     @ApiProperty()

--- a/src/shared/services/common.service.ts
+++ b/src/shared/services/common.service.ts
@@ -70,13 +70,13 @@ export class CommonService {
         compilerImage: string,
         projectFolder: string,
         contractDir: string,
-        wasmFile: string,
+        workspace: boolean,
     ): Promise<boolean> {
         let docker;
         let optimize = compilerImage.match(process.env.WORKSPACE_REGEX)
             ? '/usr/local/bin/optimize_workspace.sh'
             : '/usr/local/bin/optimize.sh';
-        let command = compilerImage.match(process.env.WORKSPACE_REGEX)
+        let command = workspace
             ? `${optimize} . && cd ${contractDir}/ && cargo schema`
             : `${optimize} . && cargo schema`;
         try {


### PR DESCRIPTION
(rather than check for compiler image format)